### PR TITLE
Feat: discussion & replies API, misc refactorings and changes

### DIFF
--- a/src/errors/responseError.ts
+++ b/src/errors/responseError.ts
@@ -1,9 +1,9 @@
 import { Response } from "express"
-import { getReasonPhrase } from "http-status-codes"
+import { StatusCodes, getReasonPhrase } from "http-status-codes"
 
 export const sendErrorResponse = (
   res: Response,
-  statusCode: number,
+  statusCode: StatusCodes,
   message: string
 ) => {
   return res

--- a/src/handlers/auth.ts
+++ b/src/handlers/auth.ts
@@ -1,5 +1,4 @@
 import { Request, Response } from "express"
-import { PrismaClient } from "@prisma/client"
 import jwt from "jsonwebtoken"
 import {
   checkEmailorUsername,
@@ -8,8 +7,7 @@ import {
   verifyPassword,
 } from "~/utils"
 import { sendErrorResponse } from "~/errors/responseError"
-
-const db = new PrismaClient()
+import { db } from "~/utils/db";
 
 // Register User
 export const registerHandler = async (req: Request, res: Response) => {

--- a/src/handlers/bookmark.ts
+++ b/src/handlers/bookmark.ts
@@ -68,24 +68,26 @@ export const createBookmarkHandler = async (req: Request, res: Response) => {
   }
 };
 
-export const getBookmarkedLocationsHandler = async (req: Request, res: Response) => {
+export const getBookmarkedLocationsHandler = async (
+  req: Request,
+  res: Response
+) => {
   const { id: userId } = req.user;
 
-  const bookmarkedLocations = await db.user.findUniqueOrThrow({
-    where: {
-      id: userId
-    },
-    select: {
-      bookmarkedLocations: true
-    }
-  });
+  const bookmarkedLocations = await db.user
+    .findUniqueOrThrow({
+      where: {
+        id: userId,
+      },
+    })
+    .bookmarkedLocations();
 
   return res.status(200).send({
     status: "OK",
     message: "Bookmarks fetched successfully",
-    ...bookmarkedLocations, // todo explain in comment why we have to spread it
+    bookmarkedLocations,
   });
-}
+};
 
 export const removeBookmarkHandler = async (req: Request, res: Response) => {
   const { locationId } = req.body;
@@ -151,4 +153,4 @@ export const removeBookmarkHandler = async (req: Request, res: Response) => {
     message: "Location removed from bookmark successfully",
     location,
   });
-}
+};

--- a/src/handlers/bookmark.ts
+++ b/src/handlers/bookmark.ts
@@ -1,8 +1,6 @@
 import { Request, Response } from "express";
-import { PrismaClient } from "@prisma/client";
 import { sendErrorResponse } from "~/errors/responseError";
-
-const db = new PrismaClient();
+import { db } from "~/utils/db";
 
 export const createBookmarkHandler = async (req: Request, res: Response) => {
   const { locationId } = req.body;

--- a/src/handlers/discussion.ts
+++ b/src/handlers/discussion.ts
@@ -31,17 +31,17 @@ export const createDiscussionHandler = async (req: Request, res: Response) => {
       data: {
         location: {
           connect: {
-            id: locationId
+            id: locationId,
           },
         },
         creator: {
           connect: {
-            id: creatorId
+            id: creatorId,
           },
         },
         title,
         content,
-      }
+      },
     });
 
     return res.status(201).send({
@@ -54,17 +54,16 @@ export const createDiscussionHandler = async (req: Request, res: Response) => {
   }
 };
 
-export const createDiscussionReplyHandler = async (req: Request, res: Response) => {
+export const createDiscussionReplyHandler = async (
+  req: Request,
+  res: Response
+) => {
   const { discussionId } = req.params;
   const { content } = req.body;
   const { id: creatorId } = req.user;
 
   if (!content) {
-    return sendErrorResponse(
-      res,
-      400,
-      "Bad request: missing content"
-    );
+    return sendErrorResponse(res, 400, "Bad request: missing content");
   }
 
   const discussion = await db.discussion.findUnique({
@@ -87,15 +86,15 @@ export const createDiscussionReplyHandler = async (req: Request, res: Response) 
         creator: {
           connect: {
             id: creatorId,
-          }
+          },
         },
         discussion: {
           connect: {
             id: discussionId,
-          }
+          },
         },
         content,
-      }
+      },
     });
 
     return res.status(201).send({
@@ -106,9 +105,12 @@ export const createDiscussionReplyHandler = async (req: Request, res: Response) 
   } catch (e) {
     return sendErrorResponse(res, 500, "Error while creating discussion reply");
   }
-}
+};
 
-export const getDiscussionRepliesHandler = async (req: Request, res: Response) => {
+export const getDiscussionRepliesHandler = async (
+  req: Request,
+  res: Response
+) => {
   const { discussionId } = req.params;
 
   const discussion = await db.discussion.findUnique({
@@ -127,17 +129,17 @@ export const getDiscussionRepliesHandler = async (req: Request, res: Response) =
 
   const replies = await db.discussionReply.findMany({
     where: {
-      discussionId
+      discussionId,
     },
     include: {
       creator: {
         select: {
           id: true,
           username: true,
-          email: true
-        }
-      }
-    }
+          email: true,
+        },
+      },
+    },
   });
 
   return res.send({
@@ -145,4 +147,4 @@ export const getDiscussionRepliesHandler = async (req: Request, res: Response) =
     message: "Replies fetched successfully",
     replies,
   });
-}
+};

--- a/src/handlers/discussion.ts
+++ b/src/handlers/discussion.ts
@@ -1,0 +1,148 @@
+import { Request, Response } from "express";
+import { PrismaClient } from "@prisma/client";
+import { sendErrorResponse } from "~/errors/responseError";
+
+const db = new PrismaClient();
+
+export const createDiscussionHandler = async (req: Request, res: Response) => {
+  const { locationId, title, content } = req.body;
+  const { id: creatorId } = req.user;
+
+  if (!locationId || !title || !content) {
+    return sendErrorResponse(res, 400, "Bad request data: missing fields");
+  }
+
+  const location = await db.location.findUnique({
+    where: {
+      id: locationId,
+    },
+  });
+
+  if (!location) {
+    return sendErrorResponse(
+      res,
+      404,
+      `Location with ID ${locationId} not found`
+    );
+  }
+
+  try {
+    const discussion = await db.discussion.create({
+      data: {
+        location: {
+          connect: {
+            id: locationId
+          },
+        },
+        creator: {
+          connect: {
+            id: creatorId
+          },
+        },
+        title,
+        content,
+      }
+    });
+
+    return res.status(201).send({
+      status: "OK",
+      message: "Discussion created successfully",
+      discussion,
+    });
+  } catch (e) {
+    return sendErrorResponse(res, 500, "Error while creating discussion");
+  }
+};
+
+export const createDiscussionReplyHandler = async (req: Request, res: Response) => {
+  const { discussionId } = req.params;
+  const { content } = req.body;
+  const { id: creatorId } = req.user;
+
+  if (!content) {
+    return sendErrorResponse(
+      res,
+      400,
+      "Bad request: missing content"
+    );
+  }
+
+  const discussion = await db.discussion.findUnique({
+    where: {
+      id: discussionId,
+    },
+  });
+
+  if (!discussion) {
+    return sendErrorResponse(
+      res,
+      404,
+      `Discussion with ID ${discussionId} not found`
+    );
+  }
+
+  try {
+    const reply = await db.discussionReply.create({
+      data: {
+        creator: {
+          connect: {
+            id: creatorId,
+          }
+        },
+        discussion: {
+          connect: {
+            id: discussionId,
+          }
+        },
+        content,
+      }
+    });
+
+    return res.status(201).send({
+      status: "OK",
+      message: "Reply created successfully",
+      reply,
+    });
+  } catch (e) {
+    return sendErrorResponse(res, 500, "Error while creating discussion reply");
+  }
+}
+
+export const getDiscussionRepliesHandler = async (req: Request, res: Response) => {
+  const { discussionId } = req.params;
+
+  const discussion = await db.discussion.findUnique({
+    where: {
+      id: discussionId,
+    },
+  });
+
+  if (!discussion) {
+    return sendErrorResponse(
+      res,
+      404,
+      `Discussion with ID ${discussionId} not found`
+    );
+  }
+
+  const replies = await db.discussionReply.findMany({
+    where: {
+      discussionId
+    },
+    include: {
+      creator: {
+        select: {
+          id: true,
+          username: true,
+          email: true
+        }
+      }
+    }
+  });
+
+  return res.send({
+    status: "OK",
+    message: "Replies fetched successfully",
+    replies,
+  });
+}

--- a/src/handlers/discussion.ts
+++ b/src/handlers/discussion.ts
@@ -1,8 +1,6 @@
 import { Request, Response } from "express";
-import { PrismaClient } from "@prisma/client";
 import { sendErrorResponse } from "~/errors/responseError";
-
-const db = new PrismaClient();
+import { db } from "~/utils/db";
 
 export const createDiscussionHandler = async (req: Request, res: Response) => {
   const { locationId, title, content } = req.body;

--- a/src/handlers/location.ts
+++ b/src/handlers/location.ts
@@ -1,8 +1,7 @@
 import { Request, Response } from "express";
-import { Prisma, PrismaClient } from "@prisma/client";
+import { Prisma } from "@prisma/client";
 import { sendErrorResponse } from "~/errors/responseError";
-
-const db = new PrismaClient();
+import { db } from "~/utils/db";
 
 export const createLocationHandler = async (req: Request, res: Response) => {
   const { label, description, lat, lon } = req.body;

--- a/src/handlers/location.ts
+++ b/src/handlers/location.ts
@@ -35,12 +35,20 @@ export const getLocationHandler = async (req: Request, res: Response) => {
   const { searchQuery, minLat, minLon, maxLat, maxLon } = req.body;
 
   // validate min-max constraints if both min and max are specified
-  if ((minLon && maxLon) && minLon > maxLon) {
-    return sendErrorResponse(res, 400, "maxLon must be greater than or equal to minLon");
+  if (minLon && maxLon && minLon > maxLon) {
+    return sendErrorResponse(
+      res,
+      400,
+      "maxLon must be greater than or equal to minLon"
+    );
   }
 
-  if ((minLat && maxLat) && minLat > maxLat) {
-    return sendErrorResponse(res, 400, "maxLat must be greater than or equal to minLat");
+  if (minLat && maxLat && minLat > maxLat) {
+    return sendErrorResponse(
+      res,
+      400,
+      "maxLat must be greater than or equal to minLat"
+    );
   }
 
   // create own custom queryFilter type with all the possible combinations
@@ -90,13 +98,15 @@ export const getLocationHandler = async (req: Request, res: Response) => {
       message: "Locations retrieved successfully",
       locations,
     });
-
   } catch (e) {
     return sendErrorResponse(res, 500, "Error while querying location");
   }
 };
 
-export const getDiscussionPerLocationHandler = async (req: Request, res: Response) => {
+export const getDiscussionPerLocationHandler = async (
+  req: Request,
+  res: Response
+) => {
   const { locationId } = req.params;
 
   const location = await db.location.findUnique({
@@ -115,7 +125,7 @@ export const getDiscussionPerLocationHandler = async (req: Request, res: Respons
 
   const discussions = await db.discussion.findMany({
     where: {
-      locationId
+      locationId,
     },
   });
 
@@ -124,4 +134,4 @@ export const getDiscussionPerLocationHandler = async (req: Request, res: Respons
     message: "Discussions fetched successfully",
     discussions,
   });
-}
+};

--- a/src/handlers/location.ts
+++ b/src/handlers/location.ts
@@ -95,3 +95,33 @@ export const getLocationHandler = async (req: Request, res: Response) => {
     return sendErrorResponse(res, 500, "Error while querying location");
   }
 };
+
+export const getDiscussionPerLocationHandler = async (req: Request, res: Response) => {
+  const { locationId } = req.params;
+
+  const location = await db.location.findUnique({
+    where: {
+      id: locationId,
+    },
+  });
+
+  if (!location) {
+    return sendErrorResponse(
+      res,
+      404,
+      `location with ID ${locationId} not found`
+    );
+  }
+
+  const discussions = await db.discussion.findMany({
+    where: {
+      locationId
+    },
+  });
+
+  return res.send({
+    status: "OK",
+    message: "Discussions fetched successfully",
+    discussions,
+  });
+}

--- a/src/handlers/sample.ts
+++ b/src/handlers/sample.ts
@@ -1,7 +1,5 @@
 import { Request, Response } from "express";
-import { PrismaClient } from "@prisma/client";
-
-const db = new PrismaClient();
+import { db } from "~/utils/db";
 
 export const sampleHandler = async (req: Request, res: Response) => {
   res.send({

--- a/src/routes/discussion.ts
+++ b/src/routes/discussion.ts
@@ -1,0 +1,10 @@
+import { Router } from "express";
+import { createDiscussionHandler, createDiscussionReplyHandler, getDiscussionRepliesHandler } from "~/handlers/discussion";
+
+const discussionRouter = Router();
+
+discussionRouter.post("/", createDiscussionHandler);
+discussionRouter.post("/:discussionId", createDiscussionReplyHandler);
+discussionRouter.get("/:discussionId", getDiscussionRepliesHandler);
+
+export default discussionRouter;

--- a/src/routes/discussion.ts
+++ b/src/routes/discussion.ts
@@ -1,5 +1,9 @@
 import { Router } from "express";
-import { createDiscussionHandler, createDiscussionReplyHandler, getDiscussionRepliesHandler } from "~/handlers/discussion";
+import {
+  createDiscussionHandler,
+  createDiscussionReplyHandler,
+  getDiscussionRepliesHandler,
+} from "~/handlers/discussion";
 
 const discussionRouter = Router();
 

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -4,6 +4,7 @@ import sampleRouter from "./sample"
 import authRouter from "./auth"
 import locationRouter from "./location";
 import bookmarkRouter from "./bookmark";
+import discussionRouter from "./discussion";
 
 const APIRouter = Router()
 
@@ -11,6 +12,7 @@ APIRouter.use("/sample", sampleRouter)
 APIRouter.use("/auth", authRouter)
 APIRouter.use("/location", authMiddleware, locationRouter)
 APIRouter.use("/bookmark", authMiddleware, bookmarkRouter)
+APIRouter.use("/discussion", authMiddleware, discussionRouter)
 
 const mainRouter = Router()
 

--- a/src/routes/location.ts
+++ b/src/routes/location.ts
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import {
     createLocationHandler,
+    getDiscussionPerLocationHandler,
     getLocationHandler
 } from "~/handlers/location";
 
@@ -8,5 +9,7 @@ const locationRouter = Router();
 
 locationRouter.post("/", createLocationHandler);
 locationRouter.get("/", getLocationHandler);
+
+locationRouter.get("/:locationId/discussion", getDiscussionPerLocationHandler);
 
 export default locationRouter;

--- a/src/routes/location.ts
+++ b/src/routes/location.ts
@@ -1,8 +1,8 @@
 import { Router } from "express";
 import {
-    createLocationHandler,
-    getDiscussionPerLocationHandler,
-    getLocationHandler
+  createLocationHandler,
+  getDiscussionPerLocationHandler,
+  getLocationHandler,
 } from "~/handlers/location";
 
 const locationRouter = Router();

--- a/src/utils/db.ts
+++ b/src/utils/db.ts
@@ -1,5 +1,5 @@
 import { PrismaClient } from "@prisma/client";
 
 export const db = new PrismaClient({
-  log: process.env.NODE_ENV === "production" ? ["warn", "error"] : ["query"],
+  log: process.env.NODE_ENV === "production" ? ["warn", "error"] : ["query", "warn", "error"],
 });

--- a/src/utils/db.ts
+++ b/src/utils/db.ts
@@ -1,0 +1,5 @@
+import { PrismaClient } from "@prisma/client";
+
+export const db = new PrismaClient({
+  log: process.env.NODE_ENV === "production" ? ["warn", "error"] : ["query"],
+});

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,8 +1,6 @@
-import { PrismaClient } from "@prisma/client"
 import bcrypt from "bcrypt"
 import jwt from "jsonwebtoken"
-
-const db = new PrismaClient()
+import { db } from "~/utils/db";
 
 export const checkEmailorUsername = async (identifier: string) => {
   if (/\S+@\S+\.\S+/.test(identifier)) {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,5 +1,5 @@
-import bcrypt from "bcrypt"
-import jwt from "jsonwebtoken"
+import bcrypt from "bcrypt";
+import jwt from "jsonwebtoken";
 import { db } from "~/utils/db";
 
 export const checkEmailorUsername = async (identifier: string) => {
@@ -9,32 +9,35 @@ export const checkEmailorUsername = async (identifier: string) => {
       where: {
         email: identifier,
       },
-    })
+    });
   } else {
     // Identifier is a username
     return await db.user.findUnique({
       where: {
         username: identifier,
       },
-    })
+    });
   }
-}
+};
 
 export const createJwtToken = (
   payload: object,
   secret: string,
   expiresIn: string
 ) => {
-  return jwt.sign(payload, secret, { expiresIn })
-}
+  return jwt.sign(payload, secret, {
+    expiresIn,
+    notBefore: "-1m",
+  }); // nbf -1 minute to allow for time skew
+};
 
 export const hashPassword = async (password: string) => {
-  return await bcrypt.hash(password, 10)
-}
+  return await bcrypt.hash(password, 10);
+};
 
 export const verifyPassword = async (
   password: string,
   hashedPassword: string
 ) => {
-  return await bcrypt.compare(password, hashedPassword)
-}
+  return await bcrypt.compare(password, hashedPassword);
+};


### PR DESCRIPTION
Implemented discussion and discussion reply API, as well as the following misc refactorings and changes:

- Used singleton for `PrismaClient` instance as per [best practice from Prisma](https://www.prisma.io/docs/orm/prisma-client/setup-and-configuration/instantiate-prisma-client#the-number-of-prismaclient-instances-matters)
- Added `PrismaClient` logging behavior
- Added http status code validation to `sendErrorResponse` 