### PR TITLE
hotfix: use search query params instead of body for GET locations

### DIFF
--- a/src/handlers/location.ts
+++ b/src/handlers/location.ts
@@ -87,7 +87,8 @@ export const addLocationImageHandler = async (req: Request, res: Response) => {
 }
 
 export const getLocationHandler = async (req: Request, res: Response) => {
-  const { searchQuery, minLat, minLon, maxLat, maxLon } = req.body;
+  // future work: actually validate types
+  const { searchQuery, minLat, minLon, maxLat, maxLon } = req.query as any;
 
   // validate min-max constraints if both min and max are specified
   if (minLon && maxLon && minLon > maxLon) {
@@ -124,7 +125,9 @@ export const getLocationHandler = async (req: Request, res: Response) => {
 
   // add label filter (case insensitive)
   if (searchQuery) {
-    queryFilter["label"] = { contains: searchQuery, mode: "insensitive" };
+    queryFilter["label"] = {
+      contains: searchQuery, mode: "insensitive"
+    };
   }
 
   // add lat filter


### PR DESCRIPTION
since according to spec, GET MUST NOT have a body